### PR TITLE
chore: pin mockgen version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ runs:
 
     - name: Install dependencies
       run: |
-        go install go.uber.org/mock/mockgen@latest
+        go install go.uber.org/mock/mockgen@v0.6.0
       shell: bash
 
     - name: Go Mod


### PR DESCRIPTION
Pins mockgen to v0.6.0