### PR TITLE
feat: implement SetChains method for dynamic chain configuration

### DIFF
--- a/pkg/tokens/manager/README.md
+++ b/pkg/tokens/manager/README.md
@@ -50,6 +50,9 @@ type Manager interface {
     DisableAutoRefresh(ctx context.Context) error
     TriggerRefresh(ctx context.Context) error
 
+    // Chain Configuration
+    SetChains(chains []uint64) error
+
     // Token Operations
     UniqueTokens() []*types.Token
     GetTokenByChainAddress(chainID uint64, addr common.Address) (*types.Token, bool)
@@ -241,6 +244,20 @@ if exists {
 allLists := manager.TokenLists()
 for _, list := range allLists {
     fmt.Printf("List: %s (%d tokens)\n", list.Name, len(list.Tokens))
+}
+```
+
+### Updating Chains
+
+You can update the manager's configured chains after creation using `SetChains`. If the manager is already started, this
+triggers an immediate rebuild of the in-memory state (native token list, parsed lists, and custom token validation) using
+the new chains. If you provided a `notifyCh` during `Start`, it will be notified after a successful rebuild.
+
+```go
+// Switch to Ethereum-only
+err := manager.SetChains([]uint64{1})
+if err != nil {
+    log.Printf("Failed to update chains: %v", err)
 }
 ```
 

--- a/pkg/tokens/manager/manager.go
+++ b/pkg/tokens/manager/manager.go
@@ -74,19 +74,23 @@ func New(config *Config,
 		return nil, ErrContentStoreNotProvided
 	}
 
+	chains, err := processChains(config.Chains)
+	if err != nil {
+		return nil, err
+	}
+
 	manager := &manager{
 		mainListID:       config.MainListID,
 		initialLists:     config.InitialLists,
 		customParsers:    config.CustomParsers,
-		chains:           config.Chains,
-		skippedTokenKeys: config.SkippedTokenKeys,
+		chains:           chains,
+		skippedTokenKeys: append([]string(nil), config.SkippedTokenKeys...),
 
 		contentStore:     contentStore,
 		customTokenStore: customTokenStore,
 	}
 
 	if config.AutoFetcherConfig != nil {
-		var err error
 		manager.autoFetcher, err = autofetcher.NewAutofetcherFromRemoteListOfTokenLists(*config.AutoFetcherConfig, fetcher,
 			contentStore)
 		if err != nil {
@@ -166,6 +170,36 @@ func (m *manager) Stop() error {
 	return nil
 }
 
+func (m *manager) notify() {
+	if m.notifyCh == nil {
+		return
+	}
+	select {
+	case m.notifyCh <- struct{}{}:
+		// notification sent
+	default:
+		// Channel is full or closed, skip notification
+	}
+}
+
+func processChains(chains []uint64) ([]uint64, error) {
+	if len(chains) == 0 {
+		return nil, ErrChainsNotProvided
+	}
+
+	processed := make([]uint64, 0, len(chains))
+	seen := make(map[uint64]struct{}, len(chains))
+	for _, c := range chains {
+		if _, exists := seen[c]; exists {
+			continue
+		}
+		seen[c] = struct{}{}
+		processed = append(processed, c)
+	}
+
+	return processed, nil
+}
+
 func (m *manager) manageRefresh(ctx context.Context) error {
 	if m.autoFetcher == nil {
 		return nil
@@ -208,14 +242,7 @@ func (m *manager) manageRefresh(ctx context.Context) error {
 					continue
 				}
 
-				if m.notifyCh != nil {
-					select {
-					case m.notifyCh <- struct{}{}:
-						// notification sent
-					default:
-						// Channel is full or closed, skip notification
-					}
-				}
+				m.notify()
 				m.mu.Unlock()
 
 			case <-refreshCtx.Done():
@@ -278,6 +305,31 @@ func (m *manager) TriggerRefresh(ctx context.Context) error {
 	}
 
 	return m.manageRefresh(ctx)
+}
+
+func (m *manager) SetChains(chains []uint64) error {
+	chains, err := processChains(chains)
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.chains = chains
+
+	// If not started yet, Start() will build initial state using the updated chains.
+	if !m.started {
+		return nil
+	}
+
+	if err := m.buildState(); err != nil {
+		return err
+	}
+
+	m.notify()
+
+	return nil
 }
 
 // UniqueTokens returns all unique tokens.

--- a/pkg/tokens/manager/manager_test.go
+++ b/pkg/tokens/manager/manager_test.go
@@ -346,6 +346,135 @@ func TestManager_TokenOperations(t *testing.T) {
 	})
 }
 
+func TestManager_SetChains(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+
+	t.Run("SetChains before Start is applied when Start builds state", func(t *testing.T) {
+		mockFetcher := mock_fetcher.NewMockFetcher(ctrl)
+		contentStore := mock_autofetcher.NewMockContentStore(ctrl)
+		customTokenStore := mock_manager.NewMockCustomTokenStore(ctrl)
+		config := createTestConfig()
+
+		contentStore.EXPECT().GetAll().Return(map[string]autofetcher.Content{}, nil).AnyTimes()
+		contentStore.EXPECT().Get(gomock.Any()).Return(autofetcher.Content{}, nil).AnyTimes()
+		customTokenStore.EXPECT().GetAll().Return([]*types.Token{}, nil).AnyTimes()
+
+		m, err := manager.New(config, mockFetcher, contentStore, customTokenStore)
+		require.NoError(t, err)
+
+		// Update chains before Start; should not rebuild yet, but should be used by Start().
+		err = m.SetChains([]uint64{common.EthereumMainnet})
+		require.NoError(t, err)
+
+		err = m.Start(ctx, false, nil)
+		require.NoError(t, err)
+		defer func() {
+			err := m.Stop()
+			require.NoError(t, err)
+		}()
+
+		tokens := m.UniqueTokens()
+		foundEth := false
+		foundBsc := false
+		for _, token := range tokens {
+			if token.ChainID == common.EthereumMainnet && token.Symbol == "ETH" {
+				foundEth = true
+			}
+			if token.ChainID == common.BSCMainnet && token.Symbol == "BNB" {
+				foundBsc = true
+			}
+		}
+		require.True(t, foundEth, "Should include ETH native token after Start with chains set pre-Start")
+		require.False(t, foundBsc, "Should not include BNB native token after Start with Ethereum-only chains set pre-Start")
+	})
+
+	t.Run("SetChains triggers rebuild and notifies when started with notifyCh", func(t *testing.T) {
+		mockFetcher := mock_fetcher.NewMockFetcher(ctrl)
+		contentStore := mock_autofetcher.NewMockContentStore(ctrl)
+		customTokenStore := mock_manager.NewMockCustomTokenStore(ctrl)
+		mockParser := mock_parsers.NewMockListOfTokenListsParser(ctrl)
+		config := createTestConfig()
+
+		config.AutoFetcherConfig = &autofetcher.ConfigRemoteListOfTokenLists{
+			Config: autofetcher.Config{
+				AutoRefreshInterval:      time.Hour,
+				AutoRefreshCheckInterval: time.Hour,
+			},
+			RemoteListOfTokenListsFetchDetails: types.ListDetails{
+				ID:        "remote-list",
+				SourceURL: "https://example.com/remote.json",
+				Schema:    "standard",
+			},
+			RemoteListOfTokenListsParser: mockParser,
+		}
+
+		contentStore.EXPECT().GetAll().Return(map[string]autofetcher.Content{}, nil).AnyTimes()
+		contentStore.EXPECT().Get(gomock.Any()).Return(autofetcher.Content{}, nil).AnyTimes()
+		customTokenStore.EXPECT().GetAll().Return([]*types.Token{}, nil).AnyTimes()
+
+		m, err := manager.New(config, mockFetcher, contentStore, customTokenStore)
+		require.NoError(t, err)
+
+		notifyCh := make(chan struct{}, 1)
+		err = m.Start(ctx, false, notifyCh) // auto refresh disabled, but notifyCh allowed because autoFetcher is configured
+		require.NoError(t, err)
+		defer func() {
+			err := m.Stop()
+			require.NoError(t, err)
+		}()
+
+		// Ensure channel is empty before SetChains.
+		for len(notifyCh) > 0 {
+			<-notifyCh
+		}
+
+		err = m.SetChains([]uint64{common.EthereumMainnet})
+		require.NoError(t, err)
+
+		select {
+		case <-notifyCh:
+			// expected
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("Expected notification after SetChains succeeds")
+		}
+
+		// Rebuild effect (BNB should be gone).
+		tokens := m.UniqueTokens()
+		foundEth := false
+		foundBsc := false
+		for _, token := range tokens {
+			if token.ChainID == common.EthereumMainnet && token.Symbol == "ETH" {
+				foundEth = true
+			}
+			if token.ChainID == common.BSCMainnet && token.Symbol == "BNB" {
+				foundBsc = true
+			}
+		}
+		require.True(t, foundEth, "Should include ETH native token after SetChains")
+		require.False(t, foundBsc, "Should not include BNB native token after SetChains to Ethereum-only")
+	})
+
+	t.Run("empty chains returns error", func(t *testing.T) {
+		mockFetcher := mock_fetcher.NewMockFetcher(ctrl)
+		contentStore := mock_autofetcher.NewMockContentStore(ctrl)
+		customTokenStore := mock_manager.NewMockCustomTokenStore(ctrl)
+		config := createTestConfig()
+
+		contentStore.EXPECT().GetAll().Return(map[string]autofetcher.Content{}, nil).AnyTimes()
+		contentStore.EXPECT().Get(gomock.Any()).Return(autofetcher.Content{}, nil).AnyTimes()
+		customTokenStore.EXPECT().GetAll().Return([]*types.Token{}, nil).AnyTimes()
+
+		m, err := manager.New(config, mockFetcher, contentStore, customTokenStore)
+		require.NoError(t, err)
+
+		err = m.SetChains([]uint64{})
+		assert.ErrorIs(t, err, manager.ErrChainsNotProvided)
+	})
+}
+
 func TestManager_CustomTokens(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/tokens/manager/types.go
+++ b/pkg/tokens/manager/types.go
@@ -26,6 +26,11 @@ type Manager interface {
 	// TriggerRefresh triggers a manual refresh of the token lists.
 	TriggerRefresh(ctx context.Context) error
 
+	// SetChains updates the manager's configured chains. If the manager is started, this triggers an immediate rebuild of
+	// the in-memory state (native tokens, parsed token lists, and custom token validation) using the new chain set.
+	// If a notify channel was provided during Start, it will be notified after a successful rebuild.
+	SetChains(chains []uint64) error
+
 	// UniqueTokens returns all unique tokens.
 	UniqueTokens() []*types.Token
 	// GetTokenByChainAddress retrieves a token by chain ID and address.


### PR DESCRIPTION
Added the SetChains method to the manager, allowing for dynamic updates to the configured chains. This change includes error handling for empty chain inputs and triggers a rebuild of the in-memory state if the manager is already started.