### PR TITLE
refactor!: update Config structure to use InitialListIDs and InitialListProvider

### DIFF
--- a/docs/specs.md
+++ b/docs/specs.md
@@ -1115,11 +1115,12 @@ type Manager interface {
 
 ```go
 type Config struct {
-    MainListID      string                                    // Primary token list ID
-    InitialLists    map[string][]byte                         // Initial token list data
+    MainListID      string                                   // Primary token list ID
+    InitialListIDs  []string                                 // Initial token list IDs
+    InitialListProvider InitialListProvider                  // Initial token list provider
     CustomParsers   map[string]parsers.TokenListParser       // Custom parsers
-    Chains          []uint64                                  // Supported chain IDs
-    AutoFetcherConfig interface{}                             // AutoFetcher configuration
+    Chains          []uint64                                 // Supported chain IDs
+    AutoFetcherConfig interface{}                            // AutoFetcher configuration
 }
 ```
 

--- a/examples/token-builder/README.md
+++ b/examples/token-builder/README.md
@@ -483,11 +483,11 @@ builder.AddNativeTokenList()
 builder.AddTokenList("uniswap", uniswapList)
 
 // Manager would use builder internally
+initialLists := map[string][]byte{"uniswap": uniswapData}
 config := &manager.Config{
     MainListID: "uniswap",
-    InitialLists: map[string][]byte{
-        "uniswap": uniswapData,
-    },
+    InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+    InitialListProvider: manager.StaticInitialListProvider(initialLists),
     Parsers: map[string]parsers.TokenListParser{
         "uniswap": &parsers.StandardTokenListParser{},
     },

--- a/examples/token-builder/go.sum
+++ b/examples/token-builder/go.sum
@@ -32,6 +32,12 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/examples/token-manager/README.md
+++ b/examples/token-manager/README.md
@@ -24,12 +24,15 @@ go run main.go
 ### 1. Manager Configuration
 
 ```go
+initialLists := map[string][]byte{
+    "uniswap-default": uniswapTokenListData,
+    "compound":        compoundTokenListData,
+}
+
 config := &manager.Config{
     MainListID: "uniswap-default",
-    InitialLists: map[string][]byte{
-        "uniswap-default": uniswapTokenListData,
-        "compound":        compoundTokenListData,
-    },
+    InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+    InitialListProvider: manager.StaticInitialListProvider(initialLists),
     CustomParsers: map[string]parsers.TokenListParser{
         "status": &parsers.StatusTokenListParser{},
     },

--- a/examples/token-manager/main.go
+++ b/examples/token-manager/main.go
@@ -179,6 +179,11 @@ func createExampleConfig() *manager.Config {
 		]
 	}`
 
+	initialLists := map[string][]byte{
+		"uniswap-default": []byte(uniswapTokenList),
+		"compound":        []byte(compoundTokenList),
+	}
+
 	return &manager.Config{
 		AutoFetcherConfig: &autofetcher.ConfigRemoteListOfTokenLists{
 			Config: autofetcher.Config{
@@ -192,11 +197,9 @@ func createExampleConfig() *manager.Config {
 			},
 			RemoteListOfTokenListsParser: &parsers.StatusListOfTokenListsParser{},
 		},
-		MainListID: "uniswap-default",
-		InitialLists: map[string][]byte{
-			"uniswap-default": []byte(uniswapTokenList),
-			"compound":        []byte(compoundTokenList),
-		},
+		MainListID:          "uniswap-default",
+		InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+		InitialListProvider: manager.StaticInitialListProvider(initialLists),
 		CustomParsers: map[string]parsers.TokenListParser{
 			"status": &parsers.StatusTokenListParser{},
 		},

--- a/pkg/tokens/manager/README.md
+++ b/pkg/tokens/manager/README.md
@@ -119,13 +119,16 @@ config := &manager.Config{
 ### Basic Configuration
 
 ```go
+initialLists := map[string][]byte{
+    "uniswap-default": uniswapTokenListData,
+    "compound":        compoundTokenListData,
+    "custom-local":    customTokenListData,
+}
+
 config := &manager.Config{
     MainListID: "uniswap-default",
-    InitialLists: map[string][]byte{
-        "uniswap-default": uniswapTokenListData,
-        "compound":        compoundTokenListData,
-        "custom-local":    customTokenListData,
-    },
+    InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+    InitialListProvider: manager.StaticInitialListProvider(initialLists),
     CustomParsers: map[string]parsers.TokenListParser{
         "custom-local": &parsers.StatusTokenListParser{}, // Custom parser needed
         // "uniswap-default" and "compound" will use StandardTokenListParser automatically
@@ -152,11 +155,14 @@ if err != nil {
 ### With Auto-Fetcher
 
 ```go
+initialLists := map[string][]byte{
+    "uniswap-default": uniswapData,
+}
+
 config := &manager.Config{
     MainListID: "uniswap-default",
-    InitialLists: map[string][]byte{
-        "uniswap-default": uniswapData,
-    },
+    InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+    InitialListProvider: manager.StaticInitialListProvider(initialLists),
     CustomParsers: map[string]parsers.TokenListParser{
         // Optional: only specify if you need non-standard parsers
         // "uniswap-default" will use StandardTokenListParser automatically
@@ -359,6 +365,8 @@ var (
     ErrAutoRefreshEnabledButNotifyChannelNotProvided = fmt.Errorf("auto refresh enabled but notify channel not provided")
     ErrManagerNotConfiguredForAutoRefresh            = fmt.Errorf("manager not configured for auto refresh")
     ErrNotFoundInInitialLists                        = fmt.Errorf("not found in initial lists")
+    ErrInitialListIDsNotProvided                     = fmt.Errorf("initial list IDs are not provided")
+    ErrInitialListProviderNotProvided                = fmt.Errorf("initial list provider is not provided")
 )
 ```
 

--- a/pkg/tokens/manager/config.go
+++ b/pkg/tokens/manager/config.go
@@ -8,10 +8,16 @@ import (
 )
 
 var (
-	ErrMainListIDNotProvided = errors.New("main list ID is not provided")
-	ErrMainListNotProvided   = errors.New("main list is not provided")
-	ErrChainsNotProvided     = errors.New("chains are not provided")
+	ErrMainListIDNotProvided          = errors.New("main list ID is not provided")
+	ErrMainListNotProvided            = errors.New("main list is not provided")
+	ErrInitialListIDsNotProvided      = errors.New("initial list IDs are not provided")
+	ErrInitialListProviderNotProvided = errors.New("initial list provider is not provided")
+	ErrChainsNotProvided              = errors.New("chains are not provided")
 )
+
+// InitialListProvider provides the raw bytes for an initial token list by its ID.
+// Implementations can load from disk, embedded assets, a database, etc.
+type InitialListProvider func(id string) ([]byte, error)
 
 // Config holds the configuration for manager.
 type Config struct {
@@ -20,8 +26,9 @@ type Config struct {
 	MainListID string // used to select the main list from the initial lists and process it first
 
 	// initial lists are processed in alphabetical order of their IDs after the main list is processed
-	InitialLists  map[string][]byte                  // key: list ID, value: list data
-	CustomParsers map[string]parsers.TokenListParser // key: list ID, value: parser, is no match for the list ID, the StandardTokenList parser will be used
+	InitialListIDs      []string                           // list of initial list IDs to process
+	InitialListProvider InitialListProvider                // provider of initial list bytes by ID
+	CustomParsers       map[string]parsers.TokenListParser // key: list ID, value: parser, is no match for the list ID, the StandardTokenList parser will be used
 
 	Chains []uint64
 
@@ -42,8 +49,23 @@ func (c *Config) Validate() error {
 	if c.MainListID == "" {
 		return ErrMainListIDNotProvided
 	}
-	_, existsInInitialLists := c.InitialLists[c.MainListID]
-	if !existsInInitialLists {
+
+	if len(c.InitialListIDs) == 0 {
+		return ErrInitialListIDsNotProvided
+	}
+
+	if c.InitialListProvider == nil {
+		return ErrInitialListProviderNotProvided
+	}
+
+	foundMain := false
+	for _, id := range c.InitialListIDs {
+		if id == c.MainListID {
+			foundMain = true
+			break
+		}
+	}
+	if !foundMain {
 		return ErrMainListNotProvided
 	}
 

--- a/pkg/tokens/manager/config_test.go
+++ b/pkg/tokens/manager/config_test.go
@@ -17,13 +17,15 @@ import (
 
 func TestConfig_Validate(t *testing.T) {
 	t.Run("valid config", func(t *testing.T) {
+		initialLists := map[string][]byte{
+			"main-list":  []byte(`{"name": "Main List", "tokens": []}`),
+			"other-list": []byte(`{"name": "Other List", "tokens": []}`),
+		}
 		config := &manager.Config{
-			MainListID: "main-list",
-			InitialLists: map[string][]byte{
-				"main-list":  []byte(`{"name": "Main List", "tokens": []}`),
-				"other-list": []byte(`{"name": "Other List", "tokens": []}`),
-			},
-			Chains: []uint64{common.EthereumMainnet, common.BSCMainnet},
+			MainListID:          "main-list",
+			InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+			InitialListProvider: manager.StaticInitialListProvider(initialLists),
+			Chains:              []uint64{common.EthereumMainnet, common.BSCMainnet},
 		}
 
 		err := config.Validate()
@@ -31,11 +33,13 @@ func TestConfig_Validate(t *testing.T) {
 	})
 
 	t.Run("empty main list ID", func(t *testing.T) {
+		initialLists := map[string][]byte{"main-list": []byte(``)}
 		config := &manager.Config{
-			MainListID:    "",
-			InitialLists:  map[string][]byte{},
-			CustomParsers: map[string]parsers.TokenListParser{},
-			Chains:        []uint64{common.EthereumMainnet},
+			MainListID:          "",
+			InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+			InitialListProvider: manager.StaticInitialListProvider(initialLists),
+			CustomParsers:       map[string]parsers.TokenListParser{},
+			Chains:              []uint64{common.EthereumMainnet},
 		}
 
 		err := config.Validate()
@@ -43,12 +47,14 @@ func TestConfig_Validate(t *testing.T) {
 	})
 
 	t.Run("main list not in initial lists", func(t *testing.T) {
+		initialLists := map[string][]byte{
+			"other-list": []byte(`{"name": "Other List", "tokens": []}`),
+		}
 		config := &manager.Config{
-			MainListID: "main-list",
-			InitialLists: map[string][]byte{
-				"other-list": []byte(`{"name": "Other List", "tokens": []}`),
-			},
-			Chains: []uint64{common.EthereumMainnet},
+			MainListID:          "main-list",
+			InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+			InitialListProvider: manager.StaticInitialListProvider(initialLists),
+			Chains:              []uint64{common.EthereumMainnet},
 		}
 
 		err := config.Validate()
@@ -56,12 +62,14 @@ func TestConfig_Validate(t *testing.T) {
 	})
 
 	t.Run("missing custom parser defaults to standard parser", func(t *testing.T) {
+		initialLists := map[string][]byte{
+			"main-list":  []byte(`{"name": "Main List", "tokens": []}`),
+			"other-list": []byte(`{"name": "Other List", "tokens": []}`),
+		}
 		config := &manager.Config{
-			MainListID: "main-list",
-			InitialLists: map[string][]byte{
-				"main-list":  []byte(`{"name": "Main List", "tokens": []}`),
-				"other-list": []byte(`{"name": "Other List", "tokens": []}`),
-			},
+			MainListID:          "main-list",
+			InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+			InitialListProvider: manager.StaticInitialListProvider(initialLists),
 			CustomParsers: map[string]parsers.TokenListParser{
 				"main-list": &parsers.CoinGeckoAllTokensParser{},
 				// no custom parser for "other-list" - should default to StandardTokenListParser
@@ -74,12 +82,14 @@ func TestConfig_Validate(t *testing.T) {
 	})
 
 	t.Run("empty chains", func(t *testing.T) {
+		initialLists := map[string][]byte{
+			"main-list": []byte(`{"name": "Main List", "tokens": []}`),
+		}
 		config := &manager.Config{
-			MainListID: "main-list",
-			InitialLists: map[string][]byte{
-				"main-list": []byte(`{"name": "Main List", "tokens": []}`),
-			},
-			Chains: []uint64{}, // empty chains
+			MainListID:          "main-list",
+			InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+			InitialListProvider: manager.StaticInitialListProvider(initialLists),
+			Chains:              []uint64{}, // empty chains
 		}
 
 		err := config.Validate()
@@ -87,12 +97,14 @@ func TestConfig_Validate(t *testing.T) {
 	})
 
 	t.Run("nil chains", func(t *testing.T) {
+		initialLists := map[string][]byte{
+			"main-list": []byte(`{"name": "Main List", "tokens": []}`),
+		}
 		config := &manager.Config{
-			MainListID: "main-list",
-			InitialLists: map[string][]byte{
-				"main-list": []byte(`{"name": "Main List", "tokens": []}`),
-			},
-			Chains: nil, // nil chains
+			MainListID:          "main-list",
+			InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+			InitialListProvider: manager.StaticInitialListProvider(initialLists),
+			Chains:              nil, // nil chains
 		}
 
 		err := config.Validate()
@@ -104,13 +116,15 @@ func TestConfig_Validate(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockParser := mock_parsers.NewMockListOfTokenListsParser(ctrl)
+		initialLists := map[string][]byte{
+			"main-list": []byte(`{"name": "Main List", "tokens": []}`),
+		}
 
 		config := &manager.Config{
-			MainListID: "main-list",
-			InitialLists: map[string][]byte{
-				"main-list": []byte(`{"name": "Main List", "tokens": []}`),
-			},
-			Chains: []uint64{common.EthereumMainnet, common.BSCMainnet},
+			MainListID:          "main-list",
+			InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+			InitialListProvider: manager.StaticInitialListProvider(initialLists),
+			Chains:              []uint64{common.EthereumMainnet, common.BSCMainnet},
 			AutoFetcherConfig: &autofetcher.ConfigRemoteListOfTokenLists{
 				Config: autofetcher.Config{
 					AutoRefreshInterval:      time.Hour,
@@ -134,13 +148,15 @@ func TestConfig_Validate(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockParser := mock_parsers.NewMockListOfTokenListsParser(ctrl)
+		initialLists := map[string][]byte{
+			"main-list": []byte(`{"name": "Main List", "tokens": []}`),
+		}
 
 		config := &manager.Config{
-			MainListID: "main-list",
-			InitialLists: map[string][]byte{
-				"main-list": []byte(`{"name": "Main List", "tokens": []}`),
-			},
-			Chains: []uint64{common.EthereumMainnet},
+			MainListID:          "main-list",
+			InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+			InitialListProvider: manager.StaticInitialListProvider(initialLists),
+			Chains:              []uint64{common.EthereumMainnet},
 			AutoFetcherConfig: &autofetcher.ConfigRemoteListOfTokenLists{
 				Config: autofetcher.Config{
 					AutoRefreshInterval:      time.Minute,
@@ -160,14 +176,16 @@ func TestConfig_Validate(t *testing.T) {
 	})
 
 	t.Run("complex valid config", func(t *testing.T) {
+		initialLists := map[string][]byte{
+			"uniswap-default": []byte(`{"name": "Uniswap Default List", "tokens": []}`),
+			"compound":        []byte(`{"name": "Compound Token List", "tokens": []}`),
+			"aave":            []byte(`{"name": "Aave Token List", "tokens": []}`),
+			"status":          []byte(`{"name": "Status Token List", "tokens": {}}`),
+		}
 		config := &manager.Config{
-			MainListID: "uniswap-default",
-			InitialLists: map[string][]byte{
-				"uniswap-default": []byte(`{"name": "Uniswap Default List", "tokens": []}`),
-				"compound":        []byte(`{"name": "Compound Token List", "tokens": []}`),
-				"aave":            []byte(`{"name": "Aave Token List", "tokens": []}`),
-				"status":          []byte(`{"name": "Status Token List", "tokens": {}}`),
-			},
+			MainListID:          "uniswap-default",
+			InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+			InitialListProvider: manager.StaticInitialListProvider(initialLists),
 			CustomParsers: map[string]parsers.TokenListParser{
 				"status": &parsers.StatusTokenListParser{},
 			},
@@ -181,12 +199,14 @@ func TestConfig_Validate(t *testing.T) {
 
 func TestConfig_ValidationEdgeCases(t *testing.T) {
 	t.Run("only main list", func(t *testing.T) {
+		initialLists := map[string][]byte{
+			"only-list": []byte(`{"name": "Only List", "tokens": []}`),
+		}
 		config := &manager.Config{
-			MainListID: "only-list",
-			InitialLists: map[string][]byte{
-				"only-list": []byte(`{"name": "Only List", "tokens": []}`),
-			},
-			Chains: []uint64{common.EthereumMainnet},
+			MainListID:          "only-list",
+			InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+			InitialListProvider: manager.StaticInitialListProvider(initialLists),
+			Chains:              []uint64{common.EthereumMainnet},
 		}
 
 		err := config.Validate()
@@ -194,14 +214,16 @@ func TestConfig_ValidationEdgeCases(t *testing.T) {
 	})
 
 	t.Run("main list with different parsers", func(t *testing.T) {
+		initialLists := map[string][]byte{
+			"main-list": []byte(`{"name": "Main List", "tokens": []}`),
+			"standard":  []byte(`{"name": "Standard List", "tokens": []}`),
+			"status":    []byte(`{"name": "Status List", "tokens": {}}`),
+			"coingecko": []byte(`{"bitcoin": {"id": "bitcoin", "platforms": {}}}`),
+		}
 		config := &manager.Config{
-			MainListID: "main-list",
-			InitialLists: map[string][]byte{
-				"main-list": []byte(`{"name": "Main List", "tokens": []}`),
-				"standard":  []byte(`{"name": "Standard List", "tokens": []}`),
-				"status":    []byte(`{"name": "Status List", "tokens": {}}`),
-				"coingecko": []byte(`{"bitcoin": {"id": "bitcoin", "platforms": {}}}`),
-			},
+			MainListID:          "main-list",
+			InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+			InitialListProvider: manager.StaticInitialListProvider(initialLists),
 			CustomParsers: map[string]parsers.TokenListParser{
 				"status":    &parsers.StatusTokenListParser{},
 				"coingecko": &parsers.CoinGeckoAllTokensParser{},
@@ -214,12 +236,14 @@ func TestConfig_ValidationEdgeCases(t *testing.T) {
 	})
 
 	t.Run("single chain configuration", func(t *testing.T) {
+		initialLists := map[string][]byte{
+			"eth-only": []byte(`{"name": "Ethereum Only", "tokens": []}`),
+		}
 		config := &manager.Config{
-			MainListID: "eth-only",
-			InitialLists: map[string][]byte{
-				"eth-only": []byte(`{"name": "Ethereum Only", "tokens": []}`),
-			},
-			Chains: []uint64{common.EthereumMainnet},
+			MainListID:          "eth-only",
+			InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+			InitialListProvider: manager.StaticInitialListProvider(initialLists),
+			Chains:              []uint64{common.EthereumMainnet},
 		}
 
 		err := config.Validate()
@@ -236,12 +260,14 @@ func TestConfig_ValidationEdgeCases(t *testing.T) {
 			common.StatusNetworkSepolia,
 		}
 
+		initialLists := map[string][]byte{
+			"multi-chain": []byte(`{"name": "Multi Chain List", "tokens": []}`),
+		}
 		config := &manager.Config{
-			MainListID: "multi-chain",
-			InitialLists: map[string][]byte{
-				"multi-chain": []byte(`{"name": "Multi Chain List", "tokens": []}`),
-			},
-			Chains: manyChains,
+			MainListID:          "multi-chain",
+			InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+			InitialListProvider: manager.StaticInitialListProvider(initialLists),
+			Chains:              manyChains,
 		}
 
 		err := config.Validate()

--- a/pkg/tokens/manager/initial_list_provider.go
+++ b/pkg/tokens/manager/initial_list_provider.go
@@ -1,0 +1,25 @@
+package manager
+
+import (
+	"fmt"
+)
+
+// StaticInitialListProvider returns an InitialListProvider from a map of initial lists.
+func StaticInitialListProvider(initialLists map[string][]byte) InitialListProvider {
+	return func(id string) ([]byte, error) {
+		b, ok := initialLists[id]
+		if !ok {
+			return nil, fmt.Errorf("%w: %s", ErrNotFoundInInitialLists, id)
+		}
+		return b, nil
+	}
+}
+
+// InitialListIDsFromMap returns a list of initial list IDs from a map of initial lists.
+func InitialListIDsFromMap(initialLists map[string][]byte) []string {
+	ids := make([]string, 0, len(initialLists))
+	for id := range initialLists {
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/pkg/tokens/manager/manager.go
+++ b/pkg/tokens/manager/manager.go
@@ -48,9 +48,10 @@ type manager struct {
 	contentStore     autofetcher.ContentStore
 	customTokenStore CustomTokenStore
 
-	mainListID    string
-	initialLists  map[string][]byte
-	customParsers map[string]parsers.TokenListParser
+	mainListID          string
+	initialListIDSet    map[string]struct{} // keeps initial list IDs and is used for fast checks of IDs existence.
+	initialListProvider InitialListProvider
+	customParsers       map[string]parsers.TokenListParser
 
 	chains []uint64
 	// skippedTokenKeys are applied when building the manager's unique token collection (see builder.Builder.GetTokens()).
@@ -80,14 +81,18 @@ func New(config *Config,
 	}
 
 	manager := &manager{
-		mainListID:       config.MainListID,
-		initialLists:     config.InitialLists,
-		customParsers:    config.CustomParsers,
-		chains:           chains,
-		skippedTokenKeys: append([]string(nil), config.SkippedTokenKeys...),
+		mainListID:          config.MainListID,
+		initialListProvider: config.InitialListProvider,
+		customParsers:       config.CustomParsers,
+		chains:              chains,
+		skippedTokenKeys:    append([]string(nil), config.SkippedTokenKeys...),
 
 		contentStore:     contentStore,
 		customTokenStore: customTokenStore,
+	}
+	manager.initialListIDSet = make(map[string]struct{}, len(config.InitialListIDs))
+	for _, id := range config.InitialListIDs {
+		manager.initialListIDSet[id] = struct{}{}
 	}
 
 	if config.AutoFetcherConfig != nil {
@@ -498,12 +503,14 @@ func (m *manager) mergeList(builder *builder.Builder, tokenListID string, fallba
 			return err
 		}
 
-		// don't return error but instead use the provided initial list
-		content.Data, exists = m.initialLists[tokenListID]
-		if !exists {
-			// this should never happen, because execution gets here only if fallbackToInitialList is true and that's the case
-			// for the initial lists (main list and other initial lists) only.
-			return ErrNotFoundInInitialLists
+		if m.initialListProvider == nil {
+			return ErrInitialListProviderNotProvided
+		}
+
+		// don't return error from `tryToGetLastFetchedTokenList` call, but instead use the provided initial list via provider
+		content.Data, err = m.initialListProvider(tokenListID)
+		if err != nil {
+			return err
 		}
 
 		content.SourceURL = LocalSourceURL
@@ -519,9 +526,9 @@ func (m *manager) mergeMainList(builder *builder.Builder) error {
 
 func (m *manager) mergeInitialLists(builder *builder.Builder) error {
 	// sort keys for deterministic order, skip main list
-	keys := make([]string, 0, len(m.initialLists))
-	for key := range m.initialLists {
-		if key == m.mainListID {
+	keys := make([]string, 0, len(m.initialListIDSet))
+	for key := range m.initialListIDSet {
+		if key == "" || key == m.mainListID {
 			continue
 		}
 		keys = append(keys, key)
@@ -547,7 +554,7 @@ func (m *manager) mergeRemoteLists(builder *builder.Builder) error {
 	// sort keys for deterministic order, skip main list and initial lists
 	keys := make([]string, 0, len(allStoredContent))
 	for key := range allStoredContent {
-		if _, exists := m.initialLists[key]; exists { // main list is also in initial lists
+		if _, exists := m.initialListIDSet[key]; exists { // main list is also in initial lists
 			continue
 		}
 		if m.remoteListOfTokenListsID != "" && key == m.remoteListOfTokenListsID {

--- a/pkg/tokens/manager/manager_test.go
+++ b/pkg/tokens/manager/manager_test.go
@@ -29,13 +29,15 @@ var (
 )
 
 func createTestConfig() *manager.Config {
+	initialLists := map[string][]byte{
+		"main-list": []byte(`{"name": "Main List", "tokens": []}`),
+		"list2":     []byte(`{"name": "List 2", "tokens": []}`),
+	}
 	return &manager.Config{
-		MainListID: "main-list",
-		InitialLists: map[string][]byte{
-			"main-list": []byte(`{"name": "Main List", "tokens": []}`),
-			"list2":     []byte(`{"name": "List 2", "tokens": []}`),
-		},
-		Chains: testChains,
+		MainListID:          "main-list",
+		InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+		InitialListProvider: manager.StaticInitialListProvider(initialLists),
+		Chains:              testChains,
 	}
 }
 


### PR DESCRIPTION
Modified the Config struct to replace InitialLists with InitialListIDs and InitialListProvider for improved flexibility in managing token lists. Updated related examples and tests to reflect these changes, ensuring compatibility with the new configuration approach.