### PR TITLE
feat: add new networks to Multicall3 addresses

### DIFF
--- a/pkg/contracts/multicall3/deployments.go
+++ b/pkg/contracts/multicall3/deployments.go
@@ -43,6 +43,7 @@ var Multicall3Addresses = map[int64]common.Address{
 	250:          common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Fantom Opera
 	64240:        common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Fantom Sonic
 	146:          common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Sonic Network
+	14601:        common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Sonic Testnet
 	56:           common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // BNB Smart Chain
 	97:           common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // BNB Smart Chain Testnet
 	5611:         common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // opBNB Testnet
@@ -61,7 +62,7 @@ var Multicall3Addresses = map[int64]common.Address{
 	14:           common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Flare Mainnet
 	19:           common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Songbird Canary Network
 	16:           common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Coston Testnet
-	114:          common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Coston2 Testnet
+	114:          common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Flare Testnet Coston2
 	288:          common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Boba
 	1313161554:   common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Aurora
 	592:          common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Astar
@@ -235,6 +236,7 @@ var Multicall3Addresses = map[int64]common.Address{
 	88817:        common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Unit Zero Testnet
 	713715:       common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Sei EVM Devnet
 	1329:         common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Sei EVM Mainnet
+	1328:         common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Sei EVM Testnet
 	167009:       common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Hekla (Taiko A7 Testnet)
 	167000:       common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Taiko Mainnet
 	7560:         common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Cyber Mainnet
@@ -280,6 +282,7 @@ var Multicall3Addresses = map[int64]common.Address{
 	132902:       common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Form Testnet
 	3338:         common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // peaq
 	10143:        common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Monad Testnet
+	143:          common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Monad
 	7869:         common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Powerloom Mainnet
 	560048:       common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Hoodi
 	6342:         common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // MegaETH Testnet
@@ -289,6 +292,12 @@ var Multicall3Addresses = map[int64]common.Address{
 	1875:         common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Whitechain
 	3799:         common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Tangle Testnet
 	8545:         common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Tangle Mainnet
+	130:          common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Unichain Mainnet
+	1301:         common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Unichain Sepolia
+	747474:       common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Katana Mainnet
+	737373:       common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Katana Bokuto
+	1868:         common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Soneium Mainnet
+	1946:         common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Soneium Minato
 	1660990954:   common.HexToAddress("0xca11bde05977b3631167028862be2a173976ca11"), // Status Network Sepolia
 }
 

--- a/pkg/contracts/multicall3/deployments/deployments.json
+++ b/pkg/contracts/multicall3/deployments/deployments.json
@@ -175,6 +175,11 @@
     "url": "https://sonicscan.org/address/0xca11bde05977b3631167028862be2a173976ca11"
   },
   {
+    "name": "Sonic Testnet",
+    "chainId": 14601,
+    "url": "https://testnet.sonicscan.org/address/0xca11bde05977b3631167028862be2a173976ca11#code"
+  },
+  {
     "name": "BNB Smart Chain",
     "chainId": 56,
     "url": "https://bscscan.com/address/0xcA11bde05977b3631167028862bE2a173976CA11#code"
@@ -265,7 +270,7 @@
     "url": "https://coston-explorer.flare.network/address/0xcA11bde05977b3631167028862bE2a173976CA11/contracts"
   },
   {
-    "name": "Coston2 Testnet",
+    "name": "Flare Testnet Coston2",
     "chainId": 114,
     "url": "https://coston2-explorer.flare.network/address/0xcA11bde05977b3631167028862bE2a173976CA11/contracts"
   },
@@ -1162,6 +1167,11 @@
     "url": "https://seitrace.com/address/0xcA11bde05977b3631167028862bE2a173976CA11?chain=pacific-1&tab=contract"
   },
   {
+    "name": "Sei EVM Testnet",
+    "chainId": 1328,
+    "url": "https://seitrace.com/address/0xcA11bde05977b3631167028862bE2a173976CA11?chain=pacific-1&contract=contract_code&slug=&tab=contract"
+  },
+  {
     "name": "Hekla (Taiko A7 Testnet)",
     "chainId": 167009,
     "url": "https://explorer.hekla.taiko.xyz/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"
@@ -1395,7 +1405,12 @@
   {
     "name": "Monad Testnet",
     "chainId": 10143,
-    "url": "https://testnet.monadexplorer.com/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=Contract"
+    "url": "https://testnet.monadvision.com/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=Contract"
+  },
+  {
+    "name": "Monad",
+    "chainId": 143,
+    "url": "https://monadvision.com/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=Contract"
   },
   {
     "name": "Powerloom Mainnet",
@@ -1441,5 +1456,35 @@
     "name": "Tangle Mainnet",
     "chainId": 8545,
     "url": "https://explorer.tangle.tools/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract"
+  },
+  {
+    "name": "Unichain Mainnet",
+    "chainId": 130,
+    "url": "https://unichain.blockscout.com/address/0xca11bde05977b3631167028862be2a173976ca11?tab=contract"
+  },
+  {
+    "name": "Unichain Sepolia",
+    "chainId": 1301,
+    "url": "https://unichain-sepolia.blockscout.com/address/0xca11bde05977b3631167028862be2a173976ca11?tab=contract"
+  },
+  {
+    "name": "Katana Mainnet",
+    "chainId": 747474,
+    "url": "https://katanascan.com/address/0xca11bde05977b3631167028862be2a173976ca11#code"
+  },
+  {
+    "name": "Katana Bokuto",
+    "chainId": 737373,
+    "url": "https://bokuto.katanascan.com/address/0xca11bde05977b3631167028862be2a173976ca11#code"
+  },
+  {
+    "name": "Soneium Mainnet",
+    "chainId": 1868,
+    "url": "https://soneium.blockscout.com/address/0xca11bde05977b3631167028862be2a173976ca11?tab=contract"
+  },
+  {
+    "name": "Soneium Minato",
+    "chainId": 1946,
+    "url": "https://soneium-minato.blockscout.com/address/0xca11bde05977b3631167028862be2a173976ca11?tab=contract"
   }
 ]


### PR DESCRIPTION
Added Multicall3 contract address for the following chains:
- Unichain Mainnet 130
- Unichain Sepolia 1301
- Katana Mainnet 747474
- Katana Bokuto 737373
- Soneium Mainnet 1868
- Soneium Minato 1946
- Sei EVM Testnet 1328
- Monad 143