### PR TITLE
feat: add support for additional native token addresses in builder and manager

### DIFF
--- a/examples/token-builder/main.go
+++ b/examples/token-builder/main.go
@@ -55,7 +55,7 @@ func main() {
 
 func demonstrateBasicBuilder(supportedChains []uint64) {
 	// Create new builder starting empty
-	tokenBuilder := builder.New(supportedChains, nil)
+	tokenBuilder := builder.New(supportedChains, nil, nil)
 
 	fmt.Printf("🏗️  Created builder for %d chains\n", len(supportedChains))
 	fmt.Printf("📊 Initial state: %d tokens, %d lists\n",
@@ -85,7 +85,7 @@ func demonstrateBasicBuilder(supportedChains []uint64) {
 
 func demonstrateIncrementalBuilding(supportedChains []uint64) {
 	// Start with empty builder
-	tokenBuilder := builder.New(supportedChains, nil)
+	tokenBuilder := builder.New(supportedChains, nil, nil)
 
 	fmt.Println("🏗️  Building token collection incrementally...")
 
@@ -128,7 +128,7 @@ func demonstrateIncrementalBuilding(supportedChains []uint64) {
 }
 
 func demonstrateRawTokenListProcessing(supportedChains []uint64) {
-	tokenBuilder := builder.New(supportedChains, nil)
+	tokenBuilder := builder.New(supportedChains, nil, nil)
 
 	// Add native tokens first
 	err := tokenBuilder.AddNativeTokenList()
@@ -234,7 +234,7 @@ func demonstrateRawTokenListProcessing(supportedChains []uint64) {
 }
 
 func demonstrateDeduplication(supportedChains []uint64) {
-	tokenBuilder := builder.New(supportedChains, nil)
+	tokenBuilder := builder.New(supportedChains, nil, nil)
 
 	// Add native tokens
 	err := tokenBuilder.AddNativeTokenList()
@@ -344,7 +344,7 @@ func demonstrateAdvancedPatterns(supportedChains []uint64) {
 
 	// Pattern 1: Builder with validation
 	fmt.Println("\n1️⃣ Builder with validation:")
-	validationBuilder := builder.New(supportedChains, nil)
+	validationBuilder := builder.New(supportedChains, nil, nil)
 	err := validationBuilder.AddNativeTokenList()
 	if err != nil {
 		log.Printf("❌ Validation failed: %v", err)
@@ -354,7 +354,7 @@ func demonstrateAdvancedPatterns(supportedChains []uint64) {
 
 	// Pattern 2: Conditional building
 	fmt.Println("\n2️⃣ Conditional building based on chain support:")
-	conditionalBuilder := builder.New([]uint64{1}, nil) // Only Ethereum
+	conditionalBuilder := builder.New([]uint64{1}, nil, nil) // Only Ethereum
 
 	// This will only include Ethereum native token
 	err = conditionalBuilder.AddNativeTokenList()
@@ -366,7 +366,7 @@ func demonstrateAdvancedPatterns(supportedChains []uint64) {
 
 	// Pattern 3: Builder state inspection
 	fmt.Println("\n3️⃣ Builder state inspection:")
-	inspectionBuilder := builder.New(supportedChains, nil)
+	inspectionBuilder := builder.New(supportedChains, nil, nil)
 	inspectionBuilder.AddNativeTokenList()
 
 	lists := inspectionBuilder.GetTokenLists()
@@ -540,7 +540,7 @@ func estimateTokenMemoryUsage(tokens map[string]*types.Token) int {
 func demonstrateErrorHandling() {
 	fmt.Println("   🛠️  Error handling examples:")
 
-	builder := builder.New([]uint64{1}, nil)
+	builder := builder.New([]uint64{1}, nil, nil)
 
 	// Test 1: Empty raw data
 	fmt.Println("      📝 Testing empty raw data...")
@@ -569,7 +569,7 @@ func demonstrateErrorHandling() {
 
 func demonstrateBuilderWithSkippedTokens(supportedChains []uint64) {
 	skippedTokenKeys := []string{"10-0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000"}
-	builder := builder.New(supportedChains, skippedTokenKeys)
+	builder := builder.New(supportedChains, skippedTokenKeys, nil)
 
 	tokenList := &types.TokenList{
 		Name: "Skipped Tokens List",

--- a/pkg/tokens/builder/README.md
+++ b/pkg/tokens/builder/README.md
@@ -10,7 +10,7 @@ The `builder` package provides functionality for building token collections by p
 
 ## Key entrypoints
 
-- `builder.New(chains, skippedTokenKeys)`
+- `builder.New(chains, skippedTokenKeys, additionalAddressesForNativeToken)`
 - `(*Builder).AddNativeTokenList()`
 - `(*Builder).AddTokenList(...)` / `(*Builder).AddRawTokenList(...)`
 - `(*Builder).GetTokens()` / `(*Builder).GetTokenLists()`
@@ -44,10 +44,11 @@ The main struct that manages incremental token list building operations:
 
 ```go
 type Builder struct {
-    chains           []uint64                     // Supported chain IDs
-    tokens           map[string]*types.Token      // Unified token collection (deduplicated)
-    tokenLists       map[string]*types.TokenList  // Individual token lists by ID
-    skippedTokenKeys map[string]bool              // Set of token keys to skip (for fast lookup)
+    chains                            []uint64                       // Supported chain IDs
+    tokens                            map[string]*types.Token        // Unified token collection (deduplicated)
+    tokenLists                        map[string]*types.TokenList    // Individual token lists by ID
+    skippedTokenKeys                  map[string]bool                // Set of token keys to skip (for fast lookup)
+    additionalAddressesForNativeToken map[uint64][]common.Address    // Extra addresses that resolve to a chain's native token
 }
 ```
 
@@ -82,13 +83,14 @@ var (
 
 ### Constructor
 
-#### `New(chains []uint64, skippedTokenKeys []string) *Builder`
+#### `New(chains []uint64, skippedTokenKeys []string, additionalAddressesForNativeToken map[uint64][]common.Address) *Builder`
 
 Creates a new Builder instance with empty token collections.
 
 **Parameters:**
 - `chains`: List of supported blockchain network IDs
 - `skippedTokenKeys`: Optional list of token keys to exclude from token collections. Token keys are in the format `"{chainID}-{lowercaseAddress}"` (e.g., `"10-0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000"`). Pass `nil` or empty slice to skip no tokens.
+- `additionalAddressesForNativeToken`: Optional map of extra addresses that should resolve to a chain's native token (e.g., zkSync Era's `0x...800a` system alias). Aliases are added to the unified token collection by `AddNativeTokenList` but are NOT added to the returned native `*types.TokenList`. Entries whose chain is not in `chains` and entries equal to the zero address are ignored.
 
 **Returns:** New Builder instance ready for incremental construction
 
@@ -96,14 +98,20 @@ Creates a new Builder instance with empty token collections.
 ```go
 chains := []uint64{1, 56, 10} // Ethereum, BSC, Optimism
 
-// Without skipping any tokens
-builder := builder.New(chains, nil)
+// Without skipping any tokens or registering aliases
+builder := builder.New(chains, nil, nil)
 
 // Skip specific tokens (e.g., invalid Optimism ETH token)
 skippedKeys := []string{
     "10-0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000", // Optimism ETH with no value
 }
-builder := builder.New(chains, skippedKeys)
+builder := builder.New(chains, skippedKeys, nil)
+
+// Register an alternative native-token address (zkSync system alias on chain 324)
+aliases := map[uint64][]common.Address{
+    324: {common.HexToAddress("0x000000000000000000000000000000000000800a")},
+}
+builder := builder.New([]uint64{324}, nil, aliases)
 
 // Builder starts empty and builds up
 ```
@@ -127,6 +135,8 @@ Returns all individual token lists indexed by their IDs.
 #### `AddNativeTokenList() error`
 
 Generates and adds native tokens for all supported chains.
+
+If `additionalAddressesForNativeToken` was passed to `New`, one extra alias entry per registered address is added directly to the unified token collection. Each alias is a value-clone of the chain's native token with `Address` overridden to the registered address; aliases are NOT added to the returned native `*types.TokenList`. Aliases respect `skippedTokenKeys` and the "first wins" rule for the unified token collection.
 
 **Example:**
 ```go
@@ -224,7 +234,7 @@ skippedKeys := []string{
     "10-0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000", // Optimism ETH
 }
 
-builder := builder.New([]uint64{10}, skippedKeys)
+builder := builder.New([]uint64{10}, skippedKeys, nil)
 
 // Add a token list containing the skipped token
 tokenList := &types.TokenList{

--- a/pkg/tokens/builder/builder.go
+++ b/pkg/tokens/builder/builder.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
+
 	"github.com/status-im/go-wallet-sdk/pkg/common"
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/parsers"
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
@@ -29,24 +31,27 @@ var (
 
 // Builder builds token lists into a single list of unique tokens.
 type Builder struct {
-	chains           []uint64
-	tokens           map[string]*types.Token
-	tokenLists       map[string]*types.TokenList
-	skippedTokenKeys map[string]bool // Set of token keys to skip (for fast lookup)
+	chains                            []uint64
+	tokens                            map[string]*types.Token
+	tokenLists                        map[string]*types.TokenList
+	skippedTokenKeys                  map[string]bool // Set of token keys to skip (for fast lookup)
+	additionalAddressesForNativeToken map[uint64][]gethcommon.Address
 }
 
 // New creates a new Builder instance.
-func New(chains []uint64, skippedTokenKeys []string) *Builder {
+func New(chains []uint64, skippedTokenKeys []string,
+	additionalAddressesForNativeToken map[uint64][]gethcommon.Address) *Builder {
 	skippedKeysMap := make(map[string]bool)
 	for _, key := range skippedTokenKeys {
 		skippedKeysMap[strings.ToLower(key)] = true
 	}
 
 	return &Builder{
-		chains:           chains,
-		tokens:           make(map[string]*types.Token),
-		tokenLists:       make(map[string]*types.TokenList),
-		skippedTokenKeys: skippedKeysMap,
+		chains:                            chains,
+		tokens:                            make(map[string]*types.Token),
+		tokenLists:                        make(map[string]*types.TokenList),
+		skippedTokenKeys:                  skippedKeysMap,
+		additionalAddressesForNativeToken: additionalAddressesForNativeToken,
 	}
 }
 
@@ -95,6 +100,25 @@ func (b *Builder) AddNativeTokenList() error {
 	}
 
 	b.AddTokenList(NativeTokenListID, nativeTokenList)
+
+	// add additional addresses for native token if configured
+	for _, chainID := range b.chains {
+		for _, addr := range b.additionalAddressesForNativeToken[chainID] {
+			if (addr == gethcommon.Address{}) {
+				continue
+			}
+			alias := *getNativeToken(chainID)
+			alias.Address = addr
+			key := alias.Key()
+			if b.skippedTokenKeys[key] {
+				continue
+			}
+			if _, exists := b.tokens[key]; !exists {
+				b.tokens[key] = &alias
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/tokens/builder/builder_test.go
+++ b/pkg/tokens/builder/builder_test.go
@@ -60,7 +60,7 @@ var (
 func TestNew(t *testing.T) {
 	chains := []uint64{common.EthereumMainnet, common.BSCMainnet}
 
-	builder := New(chains, nil)
+	builder := New(chains, nil, nil)
 
 	assert.NotNil(t, builder)
 	assert.Equal(t, chains, builder.chains)
@@ -71,7 +71,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestBuilder_GetTokens(t *testing.T) {
-	builder := New(testChains, nil)
+	builder := New(testChains, nil, nil)
 	builder.AddTokenList("test-list", testTokenList1)
 
 	result := builder.GetTokens()
@@ -79,7 +79,7 @@ func TestBuilder_GetTokens(t *testing.T) {
 }
 
 func TestBuilder_GetTokenLists(t *testing.T) {
-	builder := New(testChains, nil)
+	builder := New(testChains, nil, nil)
 	builder.AddTokenList("test-list", testTokenList1)
 
 	result := builder.GetTokenLists()
@@ -141,7 +141,7 @@ func TestGetNativeToken(t *testing.T) {
 
 func TestBuilder_AddNativeTokenList(t *testing.T) {
 	chains := []uint64{common.EthereumMainnet, common.BSCMainnet, common.OptimismMainnet}
-	builder := New(chains, nil)
+	builder := New(chains, nil, nil)
 
 	err := builder.AddNativeTokenList()
 	require.NoError(t, err)
@@ -173,7 +173,7 @@ func TestBuilder_AddNativeTokenList(t *testing.T) {
 }
 
 func TestBuilder_AddTokenList(t *testing.T) {
-	builder := New(testChains, nil)
+	builder := New(testChains, nil, nil)
 
 	tokenListID := "test-list"
 	builder.AddTokenList(tokenListID, testTokenList1)
@@ -190,7 +190,7 @@ func TestBuilder_AddTokenList(t *testing.T) {
 }
 
 func TestBuilder_AddTokenList_DuplicateTokens(t *testing.T) {
-	builder := New(testChains, nil)
+	builder := New(testChains, nil, nil)
 
 	tokenList1 := &types.TokenList{
 		Name:   "List 1",
@@ -218,7 +218,7 @@ func TestBuilder_AddRawTokenList_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	builder := New(testChains, nil)
+	builder := New(testChains, nil, nil)
 
 	rawData := []byte(`{"name": "Test List", "tokens": []}`)
 	sourceURL := "https://example.com/test.json"
@@ -244,7 +244,7 @@ func TestBuilder_AddRawTokenList_EmptyRawData(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	builder := New(testChains, nil)
+	builder := New(testChains, nil, nil)
 	mockParser := mock_parsers.NewMockTokenListParser(ctrl)
 
 	err := builder.AddRawTokenList("test-list", []byte{}, "url", time.Now(), mockParser)
@@ -255,7 +255,7 @@ func TestBuilder_AddRawTokenList_EmptyRawData(t *testing.T) {
 }
 
 func TestBuilder_AddRawTokenList_NilParser(t *testing.T) {
-	builder := New(testChains, nil)
+	builder := New(testChains, nil, nil)
 
 	err := builder.AddRawTokenList("test-list", []byte(`{}`), "url", time.Now(), nil)
 	assert.ErrorIs(t, err, ErrParserIsNil)
@@ -265,7 +265,7 @@ func TestBuilder_AddRawTokenList_ParserError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	builder := New(testChains, nil)
+	builder := New(testChains, nil, nil)
 
 	expectedError := errors.New("parser error")
 	rawData := []byte(`{}`)
@@ -281,7 +281,7 @@ func TestBuilder_AddRawTokenList_ParserError(t *testing.T) {
 }
 
 func TestBuilder_ComplexBuildScenario(t *testing.T) {
-	builder := New([]uint64{common.EthereumMainnet, common.BSCMainnet}, nil)
+	builder := New([]uint64{common.EthereumMainnet, common.BSCMainnet}, nil, nil)
 
 	err := builder.AddNativeTokenList()
 	require.NoError(t, err)
@@ -313,7 +313,7 @@ func TestBuilder_ComplexBuildScenario(t *testing.T) {
 }
 
 func TestBuilder_EmptyChains(t *testing.T) {
-	builder := New([]uint64{}, nil)
+	builder := New([]uint64{}, nil, nil)
 
 	err := builder.AddNativeTokenList()
 	require.NoError(t, err)
@@ -330,7 +330,7 @@ func TestBuilder_EmptyChains(t *testing.T) {
 }
 
 func TestBuilder_API(t *testing.T) {
-	builder := New([]uint64{common.EthereumMainnet}, nil)
+	builder := New([]uint64{common.EthereumMainnet}, nil, nil)
 
 	err := builder.AddNativeTokenList()
 	require.NoError(t, err)
@@ -346,7 +346,7 @@ func TestBuilder_API(t *testing.T) {
 }
 
 func TestBuilder_BuilderPattern_EmptyInitialization(t *testing.T) {
-	builder := New(testChains, nil)
+	builder := New(testChains, nil, nil)
 
 	assert.Empty(t, builder.GetTokens())
 	assert.Empty(t, builder.GetTokenLists())
@@ -371,7 +371,7 @@ func TestBuilder_SkipTokenKeys(t *testing.T) {
 		"10-0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000",
 	}
 
-	builder := New(testChains, skippedKeys)
+	builder := New(testChains, skippedKeys, nil)
 
 	builder.AddTokenList("test-list", testTokenList1)
 
@@ -396,11 +396,81 @@ func TestBuilder_SkipTokenKeys_CaseInsensitive(t *testing.T) {
 		strings.ToUpper(testToken1.Key()),
 	}
 
-	builder := New(testChains, skippedKeys)
+	builder := New(testChains, skippedKeys, nil)
 
 	builder.AddTokenList("test-list", testTokenList1)
 
 	tokens := builder.GetTokens()
 	assert.NotContains(t, tokens, testToken1.Key())
 	assert.Empty(t, tokens)
+}
+
+func TestBuilder_AddNativeTokenList_AdditionalAddresses(t *testing.T) {
+	zkSyncSystemNative := gethcommon.HexToAddress("0x000000000000000000000000000000000000800a")
+	chains := []uint64{common.EthereumMainnet, common.BSCMainnet}
+	additional := map[uint64][]gethcommon.Address{
+		common.EthereumMainnet: {zkSyncSystemNative},
+	}
+
+	b := New(chains, nil, additional)
+	require.NoError(t, b.AddNativeTokenList())
+
+	t.Run("alias is not added to the native token list", func(t *testing.T) {
+		nativeList := b.GetTokenLists()[NativeTokenListID]
+		require.NotNil(t, nativeList)
+		assert.Len(t, nativeList.Tokens, len(chains))
+		for _, tk := range nativeList.Tokens {
+			assert.True(t, tk.IsNative(), "native list must only contain zero-address entries")
+		}
+	})
+
+	t.Run("alias is registered in the unique-token map as a separate entry", func(t *testing.T) {
+		tokens := b.GetTokens()
+		assert.Len(t, tokens, len(chains)+1)
+
+		aliasKey := types.TokenKey(common.EthereumMainnet, zkSyncSystemNative)
+		alias, ok := tokens[aliasKey]
+		require.True(t, ok, "alias entry must be present in the unique-token map")
+
+		canonical := getNativeToken(common.EthereumMainnet)
+		assert.Equal(t, zkSyncSystemNative, alias.Address, "alias address must match what was registered")
+		assert.Equal(t, canonical.Address, gethcommon.Address{})
+		assert.Equal(t, canonical.CrossChainID, alias.CrossChainID)
+		assert.Equal(t, canonical.ChainID, alias.ChainID)
+		assert.Equal(t, canonical.Symbol, alias.Symbol)
+		assert.Equal(t, canonical.Name, alias.Name)
+		assert.Equal(t, canonical.Decimals, alias.Decimals)
+		assert.Equal(t, canonical.LogoURI, alias.LogoURI)
+	})
+}
+
+func TestBuilder_AddNativeTokenList_AdditionalAddresses_Edges(t *testing.T) {
+	zkSyncSystemNative := gethcommon.HexToAddress("0x000000000000000000000000000000000000800a")
+	chains := []uint64{common.EthereumMainnet}
+
+	t.Run("zero address is ignored", func(t *testing.T) {
+		b := New(chains, nil, map[uint64][]gethcommon.Address{
+			common.EthereumMainnet: {gethcommon.Address{}},
+		})
+		require.NoError(t, b.AddNativeTokenList())
+		assert.Len(t, b.GetTokens(), len(chains))
+	})
+
+	t.Run("entries for unknown chains are ignored", func(t *testing.T) {
+		b := New(chains, nil, map[uint64][]gethcommon.Address{
+			common.BSCMainnet: {zkSyncSystemNative}, // BSC is not in chains
+		})
+		require.NoError(t, b.AddNativeTokenList())
+		assert.Len(t, b.GetTokens(), len(chains))
+	})
+
+	t.Run("alias respects skippedTokenKeys", func(t *testing.T) {
+		aliasKey := types.TokenKey(common.EthereumMainnet, zkSyncSystemNative)
+		b := New(chains, []string{aliasKey}, map[uint64][]gethcommon.Address{
+			common.EthereumMainnet: {zkSyncSystemNative},
+		})
+		require.NoError(t, b.AddNativeTokenList())
+		_, ok := b.GetTokens()[aliasKey]
+		assert.False(t, ok, "alias must be excluded when its key is in skippedTokenKeys")
+	})
 }

--- a/pkg/tokens/manager/README.md
+++ b/pkg/tokens/manager/README.md
@@ -116,6 +116,30 @@ config := &manager.Config{
 
 **Note:** Token keys are matched case-insensitively. The filtering applies to all token sources (native tokens, remote lists, local lists, and custom tokens).
 
+### Additional Native Token Addresses
+
+Some chains expose the native token at more than one address. For example, on zkSync Era the native token is reachable both at the zero address `0x0000…0000` and at the system-contract alias `0x0000…800a`. Use `AdditionalAddressesForNativeToken` to register such per-chain aliases:
+
+- **🪞 Aliases as separate entries**: Each registered address is added to the manager's *unique token collection* as its own entry. The entry is a clone of the chain's canonical native token with `Address` set to the registered address (so callers see a `Token` whose `Address` matches what they queried). `CrossChainID` stays the same, so clients can dedupe by asset identity.
+- **📋 Native list excludes aliases**: Aliases do NOT appear in the `"native"` token list returned by `TokenList` / `TokenLists`. Those lists still contain exactly one zero-address entry per chain.
+- **🚫 Filtering and validation**: Entries whose chain is not in `Chains` and entries equal to the zero address are silently ignored. Aliases respect `SkippedTokenKeys`.
+
+```go
+config := &manager.Config{
+    Chains: []uint64{1, 324}, // Ethereum, zkSync Era
+    AdditionalAddressesForNativeToken: map[uint64][]common.Address{
+        324: { // zkSync Era native token has a system-contract alias
+            common.HexToAddress("0x000000000000000000000000000000000000800a"),
+        },
+    },
+}
+
+// After Start():
+//   GetTokenByChainAddress(324, 0x...800a) -> Token{Address: 0x...800a, Symbol: "ETH", ...}
+//   GetTokenByChainAddress(324, 0x0)       -> Token{Address: 0x0,       Symbol: "ETH", ...}
+//   TokenList("native").Tokens             -> one entry per chain (zero-address only)
+```
+
 ### Basic Configuration
 
 ```go

--- a/pkg/tokens/manager/config.go
+++ b/pkg/tokens/manager/config.go
@@ -3,6 +3,8 @@ package manager
 import (
 	"errors"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/autofetcher"
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/parsers"
 )
@@ -37,6 +39,18 @@ type Config struct {
 	//
 	// Note: this does NOT modify token lists themselves; `TokenList` / `TokenLists` still return the original lists as loaded.
 	SkippedTokenKeys []string
+
+	// AdditionalAddressesForNativeToken registers extra addresses that resolve to a chain's native token. Some chains
+	// expose the native token at more than one address (e.g. on zkSync Era the native token is reachable both at the
+	// zero address and at the system-contract alias 0x000000000000000000000000000000000000800a).
+	//
+	// Each registered address is surfaced through the manager's *unique token collection* APIs (UniqueTokens /
+	// GetTokenByChainAddress / GetTokensByChain / GetTokensByKeys) as a distinct entry whose fields match the chain's
+	// native token, except that Address is set to the registered address. It is NOT added to the "native" token list
+	// returned by `TokenList` / `TokenLists`.
+	//
+	// Entries whose chain is not in `Chains` and entries equal to the zero address are ignored.
+	AdditionalAddressesForNativeToken map[uint64][]common.Address
 }
 
 func (c *Config) Validate() error {

--- a/pkg/tokens/manager/manager.go
+++ b/pkg/tokens/manager/manager.go
@@ -57,6 +57,8 @@ type manager struct {
 	// skippedTokenKeys are applied when building the manager's unique token collection (see builder.Builder.GetTokens()).
 	// They do NOT alter token lists returned by TokenList / TokenLists (those return the original lists as loaded).
 	skippedTokenKeys []string
+	// additionalAddressesForNativeToken registers extra addresses that resolve to a chain's native token.
+	additionalAddressesForNativeToken map[uint64][]common.Address
 
 	started         bool
 	refreshCancelFn context.CancelFunc
@@ -81,11 +83,12 @@ func New(config *Config,
 	}
 
 	manager := &manager{
-		mainListID:          config.MainListID,
-		initialListProvider: config.InitialListProvider,
-		customParsers:       config.CustomParsers,
-		chains:              chains,
-		skippedTokenKeys:    append([]string(nil), config.SkippedTokenKeys...),
+		mainListID:                        config.MainListID,
+		initialListProvider:               config.InitialListProvider,
+		customParsers:                     config.CustomParsers,
+		chains:                            chains,
+		skippedTokenKeys:                  append([]string(nil), config.SkippedTokenKeys...),
+		additionalAddressesForNativeToken: cloneAddressesByChain(config.AdditionalAddressesForNativeToken),
 
 		contentStore:     contentStore,
 		customTokenStore: customTokenStore,
@@ -185,6 +188,20 @@ func (m *manager) notify() {
 	default:
 		// Channel is full or closed, skip notification
 	}
+}
+
+func cloneAddressesByChain(src map[uint64][]common.Address) map[uint64][]common.Address {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[uint64][]common.Address, len(src))
+	for chainID, addrs := range src {
+		if len(addrs) == 0 {
+			continue
+		}
+		dst[chainID] = append([]common.Address(nil), addrs...)
+	}
+	return dst
 }
 
 func processChains(chains []uint64) ([]uint64, error) {
@@ -438,7 +455,7 @@ func (m *manager) TokenLists() []*types.TokenList {
 }
 
 func (m *manager) buildState() error {
-	builder := builder.New(m.chains, m.skippedTokenKeys)
+	builder := builder.New(m.chains, m.skippedTokenKeys, m.additionalAddressesForNativeToken)
 
 	// 1. native token list
 	if err := builder.AddNativeTokenList(); err != nil {

--- a/pkg/tokens/manager/manager_test.go
+++ b/pkg/tokens/manager/manager_test.go
@@ -1094,3 +1094,156 @@ func TestManager_EmptyState(t *testing.T) {
 		assert.Nil(t, list)
 	})
 }
+
+func TestManager_AdditionalAddressesForNativeToken(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFetcher := mock_fetcher.NewMockFetcher(ctrl)
+	contentStore := mock_autofetcher.NewMockContentStore(ctrl)
+	customTokenStore := mock_manager.NewMockCustomTokenStore(ctrl)
+
+	contentStore.EXPECT().GetAll().Return(map[string]autofetcher.Content{}, nil).AnyTimes()
+	contentStore.EXPECT().Get(gomock.Any()).Return(autofetcher.Content{}, nil).AnyTimes()
+	customTokenStore.EXPECT().GetAll().Return([]*types.Token{}, nil).AnyTimes()
+
+	zkSyncSystemNative := gethcommon.HexToAddress("0x000000000000000000000000000000000000800a")
+	zeroAddr := gethcommon.Address{}
+
+	initialLists := map[string][]byte{
+		"main-list": []byte(`{"name": "Main List", "tokens": []}`),
+		"list2":     []byte(`{"name": "List 2", "tokens": []}`),
+	}
+	config := &manager.Config{
+		MainListID:          "main-list",
+		InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+		InitialListProvider: manager.StaticInitialListProvider(initialLists),
+		Chains:              testChains,
+		AdditionalAddressesForNativeToken: map[uint64][]gethcommon.Address{
+			common.EthereumMainnet: {zkSyncSystemNative},
+		},
+	}
+
+	m, err := manager.New(config, mockFetcher, contentStore, customTokenStore)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, m.Start(ctx, false, nil))
+	defer func() { _ = m.Stop() }()
+
+	aliasKey := types.TokenKey(common.EthereumMainnet, zkSyncSystemNative)
+
+	t.Run("alias does not appear in TokenList(native)", func(t *testing.T) {
+		nativeList, ok := m.TokenList("native")
+		require.True(t, ok)
+		require.NotNil(t, nativeList)
+		assert.Len(t, nativeList.Tokens, len(testChains), "native list size must match number of chains")
+		for _, tk := range nativeList.Tokens {
+			assert.True(t, tk.IsNative(), "native list must only contain zero-address entries")
+			assert.NotEqual(t, zkSyncSystemNative, tk.Address)
+		}
+	})
+
+	t.Run("GetTokenByChainAddress resolves the alias to a clone of the chain's native token", func(t *testing.T) {
+		token, ok := m.GetTokenByChainAddress(common.EthereumMainnet, zkSyncSystemNative)
+		require.True(t, ok)
+		require.NotNil(t, token)
+
+		canonicalEth, okZero := m.GetTokenByChainAddress(common.EthereumMainnet, zeroAddr)
+		require.True(t, okZero)
+		require.NotNil(t, canonicalEth)
+
+		assert.Equal(t, zkSyncSystemNative, token.Address, "alias address must round-trip")
+		assert.Equal(t, canonicalEth.CrossChainID, token.CrossChainID)
+		assert.Equal(t, canonicalEth.ChainID, token.ChainID)
+		assert.Equal(t, canonicalEth.Symbol, token.Symbol)
+		assert.Equal(t, canonicalEth.Name, token.Name)
+		assert.Equal(t, canonicalEth.Decimals, token.Decimals)
+		assert.Equal(t, canonicalEth.LogoURI, token.LogoURI)
+	})
+
+	t.Run("GetTokensByChain includes the alias as a separate entry", func(t *testing.T) {
+		ethTokens := m.GetTokensByChain(common.EthereumMainnet)
+		var sawZero, sawAlias bool
+		for _, tk := range ethTokens {
+			if tk.Address == zeroAddr {
+				sawZero = true
+			}
+			if tk.Address == zkSyncSystemNative {
+				sawAlias = true
+			}
+		}
+		assert.True(t, sawZero, "canonical zero-address native must be present")
+		assert.True(t, sawAlias, "alias entry must be present")
+
+		// Aliases configured for one chain must not leak into other chains.
+		bscTokens := m.GetTokensByChain(common.BSCMainnet)
+		for _, tk := range bscTokens {
+			assert.NotEqual(t, zkSyncSystemNative, tk.Address, "alias must not leak to other chains")
+		}
+	})
+
+	t.Run("GetTokensByKeys resolves the alias key", func(t *testing.T) {
+		tokens, err := m.GetTokensByKeys([]string{aliasKey})
+		require.NoError(t, err)
+		require.Len(t, tokens, 1)
+		assert.Equal(t, zkSyncSystemNative, tokens[0].Address)
+		assert.Equal(t, common.EthereumMainnet, tokens[0].ChainID)
+	})
+
+	t.Run("UniqueTokens includes the alias", func(t *testing.T) {
+		var sawAlias bool
+		for _, tk := range m.UniqueTokens() {
+			if tk.ChainID == common.EthereumMainnet && tk.Address == zkSyncSystemNative {
+				sawAlias = true
+				break
+			}
+		}
+		assert.True(t, sawAlias, "alias must be visible via UniqueTokens")
+	})
+}
+
+func TestManager_AdditionalAddressesForNativeToken_SkippedKeyExcludesAlias(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFetcher := mock_fetcher.NewMockFetcher(ctrl)
+	contentStore := mock_autofetcher.NewMockContentStore(ctrl)
+	customTokenStore := mock_manager.NewMockCustomTokenStore(ctrl)
+
+	contentStore.EXPECT().GetAll().Return(map[string]autofetcher.Content{}, nil).AnyTimes()
+	contentStore.EXPECT().Get(gomock.Any()).Return(autofetcher.Content{}, nil).AnyTimes()
+	customTokenStore.EXPECT().GetAll().Return([]*types.Token{}, nil).AnyTimes()
+
+	zkSyncSystemNative := gethcommon.HexToAddress("0x000000000000000000000000000000000000800a")
+	aliasKey := types.TokenKey(common.EthereumMainnet, zkSyncSystemNative)
+
+	initialLists := map[string][]byte{
+		"main-list": []byte(`{"name": "Main List", "tokens": []}`),
+		"list2":     []byte(`{"name": "List 2", "tokens": []}`),
+	}
+	config := &manager.Config{
+		MainListID:          "main-list",
+		InitialListIDs:      manager.InitialListIDsFromMap(initialLists),
+		InitialListProvider: manager.StaticInitialListProvider(initialLists),
+		Chains:              testChains,
+		SkippedTokenKeys:    []string{aliasKey},
+		AdditionalAddressesForNativeToken: map[uint64][]gethcommon.Address{
+			common.EthereumMainnet: {zkSyncSystemNative},
+		},
+	}
+
+	m, err := manager.New(config, mockFetcher, contentStore, customTokenStore)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, m.Start(ctx, false, nil))
+	defer func() { _ = m.Stop() }()
+
+	_, ok := m.GetTokenByChainAddress(common.EthereumMainnet, zkSyncSystemNative)
+	assert.False(t, ok, "alias must be excluded when its key is in SkippedTokenKeys")
+
+	tokens, err := m.GetTokensByKeys([]string{aliasKey})
+	require.NoError(t, err)
+	assert.Empty(t, tokens, "alias must not resolve via GetTokensByKeys when skipped")
+}


### PR DESCRIPTION
A new field `AdditionalAddressesForNativeToken` has been added to the `Config` type, which the client can set (if needed) for additional native addresses for some specific chains, as zkSync is.

Based on documentation: https://docs.zksync.io/zk-stack/customizations/custom-base-tokens#custom-base-token-setup
